### PR TITLE
Moved @imports to DarkDarkTheme.theme.css

### DIFF
--- a/Themes/DarkDarkTheme/DarkDarkTheme.theme.css
+++ b/Themes/DarkDarkTheme/DarkDarkTheme.theme.css
@@ -1,3 +1,15 @@
 //META{"name":"DarkDarkTheme","description":"It's Discord's Dark Theme, but Dark.","author":"Kyza#9994","version":"","website":"https://khub.kyza.gq/?theme=DarkDarkTheme","source":"https://raw.githubusercontent.com/KyzaGitHub/Khub/master/Themes/DarkDarkTheme/DarkDarkTheme.theme.css"}*//
 
+/* Base Theme, Leave me */
 @import url("https://khub.kyza.gq/Themes/DarkDarkTheme/theme.css")
+
+/* Color */
+@import url("https://khub.kyza.gq/Themes/DarkDarkTheme/colors.css");
+/* UI Changes */
+@import url("https://khub.kyza.gq/Themes/DarkDarkTheme/ui.css");
+/* Shadows */
+/* @import url("https://khub.kyza.gq/Themes/DarkDarkTheme/shadows.css"); */
+/* Utilities */
+@import url("https://khub.kyza.gq/Themes/ThemeUtilities/KyzaPFP.css");
+
+/* Don't like a part? Wrap it in brackets and stars like this to remove it! */

--- a/Themes/DarkDarkTheme/theme.css
+++ b/Themes/DarkDarkTheme/theme.css
@@ -1,13 +1,3 @@
-/* Color */
-@import url("https://khub.kyza.gq/Themes/DarkDarkTheme/colors.css");
-/* UI Changes */
-@import url("https://khub.kyza.gq/Themes/DarkDarkTheme/ui.css");
-/* Shadows */
-/* @import url("https://khub.kyza.gq/Themes/DarkDarkTheme/shadows.css"); */
-
-/* Utilities */
-@import url("https://khub.kyza.gq/Themes/ThemeUtilities/KyzaPFP.css");
-
 /* Version */
 li[data-name="DarkDarkTheme"] .bda-version:after {
   content: "2.1.2";

--- a/Themes/DarkDarkTheme/theme.css
+++ b/Themes/DarkDarkTheme/theme.css
@@ -14,7 +14,7 @@ li[data-name="DarkDarkTheme"] .bda-version:after {
 
 /* Changelog */
 li[data-name="DarkDarkTheme"] .bda-description:after {
-  content: "\A\AWhat's new in 2.1.2?\A\A Enabled the UI changes.\A@me if you find something broken!\A By the way, codeblocks now have a special font made just for code!\A Fixed the message edit box width.\A Added an icon to my profile picture.\A Fixed MemberCount.";
+  content: "\A\AWhat's new in 2.1.2?\A\A Moved some code to make it more customisable.\A@me if you find something broken!\A By the way, codeblocks now have a special font made just for code!\A Fixed the message edit box width.\A Added an icon to my profile picture.\A Fixed MemberCount.";
   white-space: pre;
 }
 


### PR DESCRIPTION
Allows users to customize their theme by simply commenting out the @import lines of segments they don't want. Would require a redownload of DarkDarkTheme.theme.css of all users of the theme however.

Possibly could split the animations and actual UI modifications into 2 separate files so that users can enable/disable each of those as well.

Version number has not been upped since I don't know your system.