### PR TITLE
Remove dupe error

### DIFF
--- a/Libraries/KSS/1KSSLibrary.plugin.js
+++ b/Libraries/KSS/1KSSLibrary.plugin.js
@@ -74,11 +74,6 @@ function KSSLibrary(plugin) {
             plugin.getName(),
             `Could not find selector for "${search.join(", ")}"!`
           );
-          ZLibrary.Toasts.error(
-            `${plugin.getName()}: Could not find selector for "${search.join(
-              ", "
-            )}"!`
-          );
         } else {
           try {
             const result = "." + res[search[search.length - 1]].split(" ")[0];


### PR DESCRIPTION
This already outputs a warning to console. No need for a big red error message in the discord window as well. This can be confusing for users also. A dev might set some elements or vars and not use them yet. But it still throws those errors and people think something is wrong.