### PR TITLE
removed invalidated kss selectors

### DIFF
--- a/Themes/DarkDarkTheme/colors.kss
+++ b/Themes/DarkDarkTheme/colors.kss
@@ -512,15 +512,9 @@
 }
 /* STOP: Various Blues */
 
-
-
 /* START: Discover/Activity Tab */
 .theme-dark |filterLabel searchBox||searchBoxInput| {
   background-color: var(--dark7);
-}
-
-.theme-dark |popoutContainer||homepageSeparator homepage||popout homepage|:hover {
-  background-color: var(--dark5);
 }
 
 /* Activity Games */
@@ -528,10 +522,6 @@
   background-color: var(--dark5);
 }
 
-/* Activity Recently Played */
-.theme-dark |whiteButton card||recentlyPlayedContainer| {
-  background-color: var(--dark2);
-}
 /* STOP: Discover/Activity Tab */
 
 
@@ -807,11 +797,6 @@
 
 /* START: Settings */
 .theme-dark |activeGame||notDetected| {
-  background-color: var(--dark2);
-}
-
-/* Search Games */
-.theme-dark |filterLabel searchBox||autocompleteScroller search| {
   background-color: var(--dark2);
 }
 /* STOP: Settings */


### PR DESCRIPTION
Thanks to some ui changes certain kss selectors stopped working. This removes them. The theme isn't adapted but it wont throw errors anymore.